### PR TITLE
PROD-1363: add serviceaccount for GKE

### DIFF
--- a/terraform/application/netbox-infra/main.tf
+++ b/terraform/application/netbox-infra/main.tf
@@ -19,8 +19,9 @@ data "google_storage_bucket" "project_bucket" {
 module "gke_autopilot" {
   source = "../../modules/gke-autopilot"
 
-  name   = local.cluster_name
-  region = var.region
+  project_id = var.project_id
+  name       = local.cluster_name
+  region     = var.region
 }
 
 module "postgresql-db" {

--- a/terraform/modules/gke-autopilot/gke.tf
+++ b/terraform/modules/gke-autopilot/gke.tf
@@ -3,7 +3,17 @@ resource "google_container_cluster" "cluster" {
   location         = var.region
   enable_autopilot = true
   network          = google_compute_network.vpc.name
-
+  node_config {
+    service_account = local.service_account
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+  }
   vertical_pod_autoscaling {
     enabled = true
   }

--- a/terraform/modules/gke-autopilot/sa.tf
+++ b/terraform/modules/gke-autopilot/sa.tf
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+locals {
+  service_account_list = compact(
+    concat(
+      google_service_account.cluster_service_account.*.email,
+      ["dummy"],
+    ),
+  )
+
+  service_account = local.service_account_list[0]
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+}
+
+resource "random_string" "cluster_service_account_suffix" {
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
+resource "google_service_account" "cluster_service_account" {
+  count        = var.create_service_account ? 1 : 0
+  project      = var.project_id
+  account_id   = "tf-gke-${substr(var.name, 0, min(15, length(var.name)))}-${random_string.cluster_service_account_suffix.result}"
+  display_name = "Terraform-managed service account for cluster ${var.name}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-log_writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_service_account.cluster_service_account[0].project
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-log_writer[0].project
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-gcr" {
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}

--- a/terraform/modules/gke-autopilot/variables.tf
+++ b/terraform/modules/gke-autopilot/variables.tf
@@ -1,3 +1,8 @@
+variable "project_id" {
+  description = "The project ID to host the cluster in."
+  type        = string
+}
+
 variable "region" {
   description = "The region to host the cluster in"
   type        = string
@@ -30,4 +35,22 @@ variable "firewall_inbound_ports" {
   type        = list(string)
   description = "List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied."
   default     = ["8443", "9443", "15017"]
+}
+
+variable "create_service_account" {
+  type        = bool
+  description = "Defines if service account specified to run nodes should be created."
+  default     = true
+}
+
+variable "grant_registry_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles."
+  default     = false
+}
+
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` and `artifactregsitry.reader` roles are assigned on these projects."
+  default     = []
 }


### PR DESCRIPTION
Our default is to delete the default compute service account when we create projects
So we need create a service account for gke autopilot to run under. 