### PR TITLE
PROD-1363: use the default service account instead of custom one

### DIFF
--- a/terraform/modules/gke-autopilot/sa.tf
+++ b/terraform/modules/gke-autopilot/sa.tf
@@ -24,7 +24,8 @@ locals {
     ),
   )
 
-  service_account = local.service_account_list[0]
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
+  service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
   registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }

--- a/terraform/modules/gke-autopilot/variables.tf
+++ b/terraform/modules/gke-autopilot/variables.tf
@@ -37,10 +37,15 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
+variable "service_account" {
+  type        = string
+  description = "The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created."
+  default     = "default"
+}
 variable "create_service_account" {
   type        = bool
   description = "Defines if service account specified to run nodes should be created."
-  default     = true
+  default     = false
 }
 
 variable "grant_registry_access" {


### PR DESCRIPTION
use the default service account instead of custom one
due to bug: https://github.com/hashicorp/terraform-provider-google/issues/9505