### PR TITLE
PROD-1363: Always run get-credentials

### DIFF
--- a/terraform/application/netbox-infra/main.tf
+++ b/terraform/application/netbox-infra/main.tf
@@ -62,9 +62,7 @@ resource "null_resource" "kube_context" {
   depends_on = [module.gke_autopilot]
 
   triggers = {
-    cluster_name = local.cluster_name
-    project_id   = var.project_id
-    region       = var.region
+    always_run = "${timestamp()}"
   }
 
   provisioner "local-exec" {

--- a/terraform/application/netbox-infra/main.tf
+++ b/terraform/application/netbox-infra/main.tf
@@ -12,7 +12,7 @@ resource "google_project_service" "default" {
 
 ##### get bucket data for terraform state
 data "google_storage_bucket" "project_bucket" {
-  name                        = "${var.project_id}-state"
+  name = "${var.project_id}-state"
 }
 
 ##### Deploy GKE autopilot cluster #####


### PR DESCRIPTION
Since we are storing state between runs. 
In CI the kubectl context doesn't get created after the first run. 